### PR TITLE
Create zend console tool and crean service definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,27 +12,32 @@ Mini-modulo con un controlador REST (user) aplicando los metodos GET, POST, PUT 
 
 ### config/module.config.php
 
-En este archivo de configuración se da de alta la ruta a al controlador que en este caso es "**/api/user**".
+En este archivo de configuración se da de alta la ruta a al controlador que en este caso es "**/api/products**".
 También configura la conexión que tengra doctrine.
 
-## Doctrine command-line
+## Zend Framework command-line
 
-Para usar los comando de Doctrine, dentro del directorio "**/module/Api/src/Doctrine**" crear un enlace al bin de doctine.
+Para ver los comandos disponibles desde la raíz del proyecto
 
-````bash
-cd module/Api/src/Doctrine 
-ln -s ../../../../vendor/bin/doctrine
+````
+php bin/console list
 ````
 
-y para usarlos basta con "**./doctrine**"
+Obtener ayuda de un comando concreto
+````
+php bin/console orm:schema-tool:create help
+````
 
-## module/Api/src/Models
+## Ejemplo de uso
+
+
 
 Dentro de este directorio se crean los archivos **PHP** que usara doctrine como entidades.
 
 ````php
 
 <?php
+// module/Api/src/Models
 
 namespace Api\Models;
 
@@ -80,8 +85,17 @@ class User
 
 ````
 
+Ahora creamos la base de datos(Este paso varía según el sistema de bbdd elegido).
 
+````
+mysql -uroot -p -e "CREATE DATABASE some_db_name;"
+````
 
+Creamos creamos el esquema de bbdd
+
+````
+php bin/console orm:schema-tool:create
+````
 
 
 ## Web server setup

--- a/bin/console
+++ b/bin/console
@@ -1,0 +1,29 @@
+#!/usr/bin/env php
+<?php
+
+use Symfony\Component\Console\Input\ArgvInput;
+use Symfony\Component\Console\Application;
+use Zend\Mvc\Application as MVC;
+
+set_time_limit(0);
+$env = (getenv('APPLICATION_ENV') ? getenv('APPLICATION_ENV') : 'production');
+defined('APPLICATION_ENV') || define('APPLICATION_ENV', $env);
+
+$loader = require __DIR__ . '/../vendor/autoload.php';
+
+$input = new ArgvInput();
+
+// Retrieve configuration
+$appConfig = require __DIR__ . '/../config/application.config.php';
+if ('development' === $env && file_exists(__DIR__ . '/../config/development.config.php')) {
+    $appConfig = \Zend\Stdlib\ArrayUtils::merge($appConfig, require __DIR__ . '/../config/development.config.php');
+}
+
+$zend = MVC::init($appConfig);
+$serviceManager = $zend->getServiceManager();
+
+$console = new Application('Zend Framework 3 Console tool', '0.0.1');
+
+require_once __DIR__ . '/../config/autoload/commands.php';
+
+$console->run($input);

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,9 @@
 {
   "name" : "ddniel16/zf3-doctrine",
   "description" : "Skeleton Application for Zend Framework zend-mvc applications with Doctrine 2",
+  "type" : "project",
+  "license" : "BSD-3-Clause",
+  "keywords" : [ "framework", "mvc", "zf", "doctrine" ],
   "require" : {
     "php" : "^5.6 || ^7.0",
     "zendframework/zend-component-installer" : "^1.0 || ^0.3 || ^1.0.0-dev@dev",
@@ -8,24 +11,23 @@
     "zfcampus/zf-development-mode" : "^3.0",
     "zendframework/zend-http" : "^2.5",
     "zendframework/zend-json" : "3.0.0",
-    "doctrine/orm" : "^2.5"
+    "doctrine/orm" : "^2.5",
+    "drkp/doctrine-metadata-configuration-factory": "@dev"
   },
-  "license" : "BSD-3-Clause",
-  "keywords" : [ "framework", "mvc", "zf", "doctrine" ],
-  "autoload-dev" : {
-    "psr-4" : {
-      "ApplicationTest\\" : "module/Application/test/"
-    }
-  },
-  "extra" : [ ],
-  "minimum-stability" : "dev",
   "autoload" : {
     "psr-4" : {
       "Application\\" : "module/Application/src/",
       "Api\\" : "module/Api/src/"
     }
   },
-  "type" : "project",
+  "autoload-dev" : {
+    "psr-4" : {
+      "ApplicationTest\\" : "module/Application/test/"
+    }
+  },
+  "config": {
+    "bin-dir": "./bin"
+  },
   "scripts" : {
     "cs-check" : "phpcs",
     "cs-fix" : "phpcbf",
@@ -36,6 +38,8 @@
     "serve" : "php -S 0.0.0.0:8080 -t public/ public/index.php",
     "test" : "phpunit"
   },
+  "extra" : [ ],
   "homepage" : "http://framework.zend.com/",
+  "minimum-stability" : "dev",
   "prefer-stable" : true
 }

--- a/config/autoload/commands.php
+++ b/config/autoload/commands.php
@@ -1,0 +1,16 @@
+<?php
+
+$console->setHelperSet(
+    new Symfony\Component\Console\Helper\HelperSet([
+        'db' => new \Doctrine\DBAL\Tools\Console\Helper\ConnectionHelper(
+            $serviceManager->get(\Doctrine\ORM\EntityManager::class)->getConnection()
+        ),
+        'em' => new \Doctrine\ORM\Tools\Console\Helper\EntityManagerHelper(
+            $serviceManager->get(\Doctrine\ORM\EntityManager::class)
+        )
+    ])
+);
+
+\Doctrine\DBAL\Tools\Console\ConsoleRunner::addCommands($console);
+\Doctrine\ORM\Tools\Console\ConsoleRunner::addCommands($console);
+

--- a/module/Api/config/module.config.php
+++ b/module/Api/config/module.config.php
@@ -8,16 +8,17 @@
 namespace Api;
 
 use Zend\Router\Http\Segment;
+use Zend\ServiceManager\Factory\InvokableFactory;
 
 return [
     'router' => [
         'routes' => [
-            'user' => [
-                'type'    => Segment::class,
+            'products' => [
+                'type'    => 'segment',
                 'options' => [
-                    'route' => '/api/user[/:id]',
+                    'route' => '/api/products[/:id]',
                     'defaults' => [
-                        'controller' => Controller\UserController::class
+                        'controller' => Controller\ProductsController::class,
                     ],
                 ],
             ],
@@ -28,13 +29,21 @@ return [
             'api' => __DIR__ . '/../view',
         ],
     ],
-    'doctrine' => [
-        'driver' => 'pdo_mysql',
-        'host' => '127.0.0.1',
-        'port' => '3306',
-        'dbname' => '{db}',
-        'user' => '{user}',
-        'password' => '{pass}',
-        'charset' => 'utf8'
+    'dbal' => [
+        'db.options' => [
+            'driver' => 'pdo_sqlite',
+            'path' =>  __DIR__ . '/../../../data/db.sqlite'
+        ],
+    ],
+    'orm' => [
+        "orm.em.options" => [
+            "mappings" => [
+                [
+                    "type" => "annotation",
+                    "namespace" => "Api",
+                    "path" => realpath(__DIR__ . "/../src/Models"),
+                ],
+            ],
+        ],
     ]
 ];

--- a/module/Api/src/Controller/ProductsController.php
+++ b/module/Api/src/Controller/ProductsController.php
@@ -7,36 +7,33 @@
 
 namespace Api\Controller;
 
+use Doctrine\ORM\EntityManagerInterface;
+use Zend\Http\Request;
 use Zend\Http\Response;
 use Zend\Mvc\Controller\AbstractRestfulController;
 use Zend\Json\Json;
-use Api\Module;
 
-class UserController
-    extends AbstractRestfulController
+class ProductsController extends AbstractRestfulController
 {
-
-    protected $_table;
     protected $_config;
     protected $_doctrine;
 
-    public function __construct(\Doctrine\ORM\EntityManager $doctrine)
+    public function __construct(EntityManagerInterface $doctrine, array $config)
     {
-
-        $this->_config = Module::getConfig();
+        $this->_config = $config;
         $this->_doctrine = $doctrine;
     }
 
     public function getList()
     {
 
-        $products = $this->_doctrine->getRepository('Api\Models\Product');
+        $repository = $this->_doctrine->getRepository('Api\Models\Product');
 
         $result = array();
-        $users = $products->findAll();
+        $products = $repository->findAll();
 
-        foreach ($users as $user) {
-            $result[] = $user->toArray();
+        foreach ($products as $product) {
+            $result[] = $product->toArray();
         }
 
         $response = $this->getResponse();
@@ -52,8 +49,8 @@ class UserController
     public function get($id)
     {
 
-        $products = $this->_doctrine->getRepository('Api\Models\Product');
-        $product = $products->find($id);
+        $repository = $this->_doctrine->getRepository('Api\Models\Product');
+        $product = $repository->find($id);
         $result = $product->toArray();
 
         $response = $this->getResponse();
@@ -92,8 +89,8 @@ class UserController
     public function update($id, $data)
     {
 
-        $products = $this->_doctrine->getRepository('Api\Models\Product');
-        $product = $products->find($id);
+        $repository = $this->_doctrine->getRepository('Api\Models\Product');
+        $product = $repository->find($id);
 
         $product->setName($data['name']);
 
@@ -118,8 +115,8 @@ class UserController
     public function delete($id)
     {
 
-        $products = $this->_doctrine->getRepository('Api\Models\Product');
-        $product = $products->find($id);
+        $repository = $this->_doctrine->getRepository('Api\Models\Product');
+        $product = $repository->find($id);
 
         $this->_doctrine->remove($product);
         $this->_doctrine->flush();


### PR DESCRIPTION
Creo que habría que dividirlo en tres partes..

El primer paso sería sacar la parte de doctrine del  módulo Api y crear un nuevo módulo de configuración algo como `ZF3doctrineORMAdapter`.

Este módulo solo se debería encargar de validar el array de configuraciones para doctrine y de crear los servicios que se necesiten para crear el `EntityManager`,  pero no crearlo, ya que es mejor dejar la definición del `EntityManager` para las necesidades de cada aplicación que lo utilice.

Saque una parte que era complicada de la config de doctrine a un paquete a parte que se puede descargar de packagist con composer, lo único que hace es facilitar un poco lo del mapping, para poder hacer como prefiramos `yaml`, `xml` o anotaciones. https://packagist.org/packages/drkp/doctrine-metadata-configuration-factory

El segundo paso sería el cambio de nombre de ruta, que sin más.

Y el tercero sería integrar el console tool de Symfony a Zend, creo que debería ser otro módulo a parte y que al instalarse te creara el symlink o el archivo "bin/console", lo guapo de la consola es que tienes toda la configuración y servicios que tengas dados de alta en zend, por lo que crear comandos nuevos para cualquier tarea, seria super facil. 

Creo que eso es todo

Un saludo

P.D. He cambiado de mysql a sqlite solo para probar